### PR TITLE
7/23 edits

### DIFF
--- a/MaximoBot-action.json
+++ b/MaximoBot-action.json
@@ -282,7 +282,7 @@
                       "text_expression": {
                         "concat": [
                           {
-                            "scalar": "View Maximo [assets at risk dashboard](https://main.manage.tmpmas90wo.ibmmasivt.com/maximo/oslc/graphite/relengineer/index.html?fromMenu=false&xyRanges=70%2C100%2C40%2C60%2C70%2C100%2C20%2C40%2C40%2C70%2C80%2C100%2C40%2C70%2C60%2C80%2C40%2C70%2C40%2C60%2C40%2C70%2C20%2C40&title=Medium&xAxis=EOL&yAxis=CRITICALITY#/health){{target=\"_self\" rel=\"noopener noreferrer\"}}."
+                            "scalar": "View Maximo [assets at risk dashboard]({maximo url}/maximo/oslc/graphite/relengineer/index.html?fromMenu=false&xyRanges=70%2C100%2C40%2C60%2C70%2C100%2C20%2C40%2C40%2C70%2C80%2C100%2C40%2C70%2C60%2C80%2C40%2C70%2C40%2C60%2C40%2C70%2C20%2C40&title=Medium&xAxis=EOL&yAxis=CRITICALITY#/health){{target=\"_self\" rel=\"noopener noreferrer\"}}."
                           },
                           {
                             "scalar": "\n\n<br />\n\n\n\nGetting a list of assets at high risk ..."

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Click the 'Add' button on the extension and follow the steps until you come to '
 
 ![alt text](images/add-extension.png) 
 
-The credentials you put in are visible here. Your server URL from your openapi.json file will be shown at the bottom of the page.
+The credentials you put in are visible here. Your server URL from your `openapi.json` file will be shown at the bottom of the page.
 
 ![alt text](images/auth.png)
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ The running code below shows you how to run the code using docker and command li
 ### Build and deploy a Docker image
 Install a containerisation tool of choice and install docker.
 
-Set the MAXIMO_SERVER_ENV value to your maximo manage hostname
+Cloned the code repository. Then, create a new .env file in the wxo-maximo-integration folder.
+
+In the .env file, set the MAXIMO_SERVER_ENV value to your maximo manage hostname:
 ```
 MAXIMO_SERVER_ENV={enter your hostname}
 ```
@@ -99,8 +101,6 @@ This ends the setting up of your conda environment.
 #### 3. Starting the Service
 When you have cloned the code repository, installed and created your conda environment, and activated the environment, 
 you can then start the REST API service.
-
-In your .env file set your MAXIMO_SERVER_ENV value to be your maximo manage hostname.
 
 Navigate to the location of the main.py file in the src/app folder.
 
@@ -225,7 +225,7 @@ Click the 'Add' button on the extension and follow the steps until you come to '
 
 ![alt text](images/add-extension.png) 
 
-This shows the credentials put in and your server will shown at the bottom of the page from your openapi.json file.
+The credentials you put in are visible here. Your server URL from your openapi.json file will be shown at the bottom of the page.
 
 ![alt text](images/auth.png)
 
@@ -258,7 +258,7 @@ Once that has been uploaded click on 'Close' in the top right for the settings. 
 ![alt text](images/maximo-actions-added.png)
 
 ### 5. Preview the assistant
-At this point you have configured all the required items in Watsonx Orchestrate and the assistant. You can preview the assistant by clicking on 'Preview' on the left hadn menu.
+At this point you have configured all the required items in Watsonx Orchestrate and the assistant. You can preview the assistant by clicking on 'Preview' on the left hand menu.
 
 ![alt text](images/preview-assistant.png)
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The running code below shows you how to run the code using docker and command li
 ### Build and deploy a Docker image
 Install a containerisation tool of choice and install docker.
 
-Cloned the code repository. Then, create a new .env file in the wxo-maximo-integration folder.
+Clone the code repository. Then, create a new .env file in the wxo-maximo-integration folder.
 
 In the .env file, set the MAXIMO_SERVER_ENV value to your maximo manage hostname:
 ```

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ The running code below shows you how to run the code using docker and command li
 ### Build and deploy a Docker image
 Install a containerisation tool of choice and install docker.
 
-Clone the code repository. Then, create a new .env file in the wxo-maximo-integration folder.
+Clone the code repository. Then, create a new `.env` file in the wxo-maximo-integration folder.
 
-In the .env file, set the MAXIMO_SERVER_ENV value to your maximo manage hostname:
+In the `.env` file, set the `MAXIMO_SERVER_ENV` value to your Maximo Manage hostname:
 ```
 MAXIMO_SERVER_ENV={enter your hostname}
 ```

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -13,6 +13,9 @@ from random import randint, randrange
 from datetime import date
 import os
 from routers import hello
+from dotenv import load_dotenv
+
+load_dotenv()
 
 maximo_server = os.environ['MAXIMO_SERVER_ENV']
 


### PR DESCRIPTION
Made changes to the readme file so that the create .env step is first, since the docker image deployment is dependent on the .env file. Additional changes for clarity.

Removed the maximo url that was hard-coded into the actions json.

Added dotenv import and load_dotenv() to main.py, so that the MAXIMO_SERVER_ENV variable set in .env is picked up automatically and the user doesn't need to export MAXIMO_SERVER_ENV in the terminal.